### PR TITLE
Remove solidity solium warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 __pycache__
 /data/
 agent/tests/output
-
+node_modules/
+package-lock.json

--- a/dao/.soliumrc.json
+++ b/dao/.soliumrc.json
@@ -1,9 +1,13 @@
 {
   "extends": "solium:all",
+  "plugins": [
+    "security"
+  ],
   "rules": {
     "indentation": ["error", 4],
     "quotes": ["error", "double"],
-    "arg-overflow": "off",
-    "blank-lines": "off"
+    "arg-overflow": "warning",
+    "blank-lines": "warning",
+    "security/no-block-members": "warning"
   }
 }

--- a/dao/contracts/Migrations.sol
+++ b/dao/contracts/Migrations.sol
@@ -10,15 +10,15 @@ contract Migrations {
             _;
     }
 
-    function Migrations() {
+    function Migrations()  public {
         owner = msg.sender;
     }
 
-    function setCompleted(uint completed) restricted {
+    function setCompleted(uint completed) restricted  public {
         last_completed_migration = completed;
     }
 
-    function upgrade(address newAddress) restricted {
+    function upgrade(address newAddress) restricted  public {
         Migrations upgraded = Migrations(newAddress);
         upgraded.setCompleted(last_completed_migration);
     }

--- a/dao/contracts/agent/Agent.sol
+++ b/dao/contracts/agent/Agent.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.18;
 import "./AgentInterface.sol";
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 
+
 contract Agent is AgentInterface, Ownable {
 
     bytes[] public packets;

--- a/dao/contracts/agent/AgentFactory.sol
+++ b/dao/contracts/agent/AgentFactory.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.18;
 
 import "./Agent.sol";
 
+
 contract AgentFactory {
 
     function create() public returns (Agent) {

--- a/dao/contracts/agent/AgentInterface.sol
+++ b/dao/contracts/agent/AgentInterface.sol
@@ -2,11 +2,12 @@ pragma solidity ^0.4.18;
 
 import "../market/MarketJob.sol";
 
+
 contract AgentInterface {
 
     function sendPacket(address target, bytes packet) external;
     function appendPacket(bytes packet) external;
     function getPacket(uint id) external constant returns (bytes);
     function setJob(MarketJob _job) external returns (address);
-    
+
 }

--- a/dao/contracts/market/Escrow.sol
+++ b/dao/contracts/market/Escrow.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.11;
 
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";
 
+
 contract Escrow is Ownable {
 
 
@@ -9,11 +10,11 @@ contract Escrow is Ownable {
 
     event Deposited(address indexed from, uint amount);
 
-    function Escrow(address _beneficiary) {
+    function Escrow(address _beneficiary)  public {
         beneficiary = _beneficiary;
     }
 
-    function () payable {
+    function () payable  public {
         if (msg.value <= 0) {
             return;
         }
@@ -21,7 +22,7 @@ contract Escrow is Ownable {
         Deposited(msg.sender, msg.value);
     }
 
-    function releaseFunds() onlyOwner {
+    function releaseFunds() onlyOwner  public {
         beneficiary.transfer(this.balance);
     }
 }

--- a/dao/contracts/market/MarketJob.sol
+++ b/dao/contracts/market/MarketJob.sol
@@ -54,14 +54,15 @@ contract MarketJob is MarketJobInterface {
         _;
     }
 
-    function MarketJob(
+    function MarketJob (
         address[] _agents,
         uint256[] _amounts,
         uint256[] _services,
         address _token,
         address _payer,
         bytes _jobDescriptor
-    ) {
+    )  public
+    {
         require(_agents.length == _amounts.length);
         require(_amounts.length == _services.length);
         masterAgent = msg.sender;

--- a/dao/contracts/market/MarketJobFactory.sol
+++ b/dao/contracts/market/MarketJobFactory.sol
@@ -2,24 +2,25 @@ pragma solidity ^0.4.18;
 
 import "./MarketJob.sol";
 
+
 contract MarketJobFactory {
 
     event Created(address creator, address contractAddress);
 
     function create(
-        address[] agents, 
-        uint256[] amounts, 
-        uint256[] services, 
-        address token, 
-        address payer, 
-        bytes firstPacket ) public returns (MarketJob) 
+        address[] agents,
+        uint256[] amounts,
+        uint256[] services,
+        address token,
+        address payer,
+        bytes firstPacket ) public returns (MarketJob)
     {
         MarketJob marketJob = new MarketJob(
-            agents, 
-            amounts, 
-            services, 
-            token, 
-            payer, 
+            agents,
+            amounts,
+            services,
+            token,
+            payer,
             firstPacket
         );
 

--- a/dao/contracts/tokens/SingularityNetToken.sol
+++ b/dao/contracts/tokens/SingularityNetToken.sol
@@ -29,26 +29,26 @@ contract SingularityNetToken is PausableToken, BurnableToken {
     uint256 public constant INITIAL_SUPPLY = 1000000000 * 10**uint256(DECIMALS);
 
     uint256 public constant PRIVATE_SUPPLY =  200000000 * 10**uint256(DECIMALS);
-    uint256 public constant ADVISORS_SUPPLY = 100000000 * 10**uint256(DECIMALS); 
+    uint256 public constant ADVISORS_SUPPLY = 100000000 * 10**uint256(DECIMALS);
     uint256 public constant PUBLIC_SUPPLY  =  700000000 * 10**uint256(DECIMALS);
-    
+
     /**
     * @dev SingularityNetToken Constructor
     */
 
-    function SingularityNetToken() {
-        totalSupply = INITIAL_SUPPLY;   
+    function SingularityNetToken()  public {
+        totalSupply = INITIAL_SUPPLY;
         balances[msg.sender] = INITIAL_SUPPLY;
     }
 
-    function setOwnership(address _owner) onlyOwner {
+    function setOwnership(address _owner) onlyOwner public {
         pause();
         balances[owner] = INITIAL_SUPPLY.sub(PUBLIC_SUPPLY);
         owner = _owner;
         balances[owner] = PUBLIC_SUPPLY;
-    } 
+    }
 
-    function transferTokens(address beneficiary, uint256 amount) onlyOwner returns (bool) {
+    function transferTokens(address beneficiary, uint256 amount) onlyOwner public returns (bool) {
         require(amount > 0);
 
         balances[owner] = balances[owner].sub(amount);

--- a/dao/package.json
+++ b/dao/package.json
@@ -13,12 +13,13 @@
   "license": "MIT",
   "dependencies": {
     "ganache-cli": "^6.0.3",
+    "scrypt": "6.0.1",
     "truffle-hdwallet-provider": "0.0.3",
     "zeppelin-solidity": "^1.4.0",
-    "scrypt": "6.0.1"
+    "solium": "1.0.9"
   },
   "repository": {
-  "type": "git",
-  "url": "git://github.com/singnet/singnet/repository.git"
+    "type": "git",
+    "url": "git://github.com/singnet/singnet/repository.git"
   }
 }

--- a/dao/test/helpers/AgiCrowdsaleMock.sol
+++ b/dao/test/helpers/AgiCrowdsaleMock.sol
@@ -2,8 +2,22 @@ pragma solidity ^0.4.18;
 
 import "../../contracts/foundation/AgiCrowdsale.sol";
 
+
 contract AgiCrowdsaleMock is AgiCrowdsale {
     uint256 public timeStamp = now;
+
+    function AgiCrowdsaleMock(
+        address _token,
+        address _wallet,
+        uint256 _startTime,
+        uint256 _endTime,
+        uint256 _rate,
+        uint256 _cap,
+        uint256 _goal)
+        AgiCrowdsale(_token, _wallet, _startTime, _endTime, _rate, _cap, _goal) public
+    {
+    }
+
     function setBlockTimestamp(uint256 _timeStamp) public onlyOwner {
         timeStamp = _timeStamp;
     }
@@ -11,17 +25,6 @@ contract AgiCrowdsaleMock is AgiCrowdsale {
     function getBlockTimestamp() internal constant returns (uint256) {
         return timeStamp;
     }
-  
-    function AgiCrowdsaleMock(
-        address _token, 
-        address _wallet, 
-        uint256 _startTime, 
-        uint256 _endTime, 
-        uint256 _rate, 
-        uint256 _cap, 
-        uint256 _goal) 
-        AgiCrowdsale(_token, _wallet, _startTime, _endTime, _rate, _cap, _goal)
-    {
-    }
+
 
 }

--- a/dao/test/helpers/SingularityNetTokenMock.sol
+++ b/dao/test/helpers/SingularityNetTokenMock.sol
@@ -2,9 +2,10 @@ pragma solidity ^0.4.18;
 
 import "../../contracts/tokens/SingularityNetToken.sol";
 
+
 contract SingularityNetTokenMock is SingularityNetToken {
 
-    function SingularityNetTokenMock( address owner, uint256 supply) {  
+    function SingularityNetTokenMock( address owner, uint256 supply) public {
         balances[owner] = supply;
     }
 


### PR DESCRIPTION
While I've been trying to get `truffle test` to work, I wanted to see what changes were required to eliminate the warnings from both the solc compile and the solium linter. I'm not going to merge this myself, but after you check it out @tiero, please do so.

None of the changes here change behavior in any way, they are three different types:

1) Some classes needed an extra whitespace line or two
2) Some functions needed an explicit "public" because no access modifier was present
3) In a couple files, the internal functions needed to be moved down to remove an order warning
4) Solium removed some extra trailing whitespace when I tried the --fix flag

After these changes, there is only one warning remaining: "block.timestamp" and I don't think there is any way to avoid that warning, at the moment, since you need the timestamp.